### PR TITLE
Fix Gondola being inactive after crash

### DIFF
--- a/src/app/common/level/run-cleanup-handler.ts
+++ b/src/app/common/level/run-cleanup-handler.ts
@@ -26,7 +26,16 @@ export class RunCleanupHandler extends RunStateHandler {
             socketHandler.addCommand(OgCommand.ResetGame);
 
         //import task statuses to game
-        runStateHandler.tasksStatuses.forEach(interaction => {
+        //import warp gate tasks first, to ensure gondola is made active upon game restart (e.g. a crash)
+        //TODO: Prevent exploitation here! Currently it does not care if you should have the gondola unlocked or not, so a player
+        //could relaunch the game after hitting the button to gain access to Snowy immediately.
+        runStateHandler.tasksStatuses.filter(x => Task.isWarpGate(x.interName)).forEach(interaction => {
+            const modifiedInteraction = interaction;
+            modifiedInteraction.interCleanup = true;
+            this.resendCommonInteraction(modifiedInteraction, socketHandler, true);
+        });
+          
+        runStateHandler.tasksStatuses.filter(x => !Task.isWarpGate(x.interName)).forEach(interaction => {
             const modifiedInteraction = interaction;
             modifiedInteraction.interCleanup = true;
             this.resendCommonInteraction(modifiedInteraction, socketHandler, true);

--- a/src/app/common/opengoal/level.ts
+++ b/src/app/common/opengoal/level.ts
@@ -64,7 +64,7 @@ export class Level {
             case Level.hub2:
                 return "Rock Village";
             case Level.hub3:
-                return "Volcanic Crate";
+                return "Volcanic Crater";
             default:
                 return "";
         }

--- a/src/app/common/opengoal/task.ts
+++ b/src/app/common/opengoal/task.ts
@@ -191,7 +191,7 @@ export class Task {
         ]).includes(gameTask);
     }
 
-    public static generateIneractionForHubGate(hub: number) : InteractionData | undefined {
+    public static generateInteractionForHubGate(hub: number) : InteractionData | undefined {
         switch(hub) {
             case 2:
                 return {

--- a/src/app/common/socket/socket-handler-lockout.ts
+++ b/src/app/common/socket/socket-handler-lockout.ts
@@ -49,7 +49,7 @@ export class SocketHandlerLockout extends SocketHandler {
 
             //open warp gate on new hub cell
             //!TODO: could probably been done cleaner than to generate one gate task per cell
-            let gateTask = Task.generateIneractionForHubGate(Task.getTaskHub(task.name));
+            let gateTask = Task.generateInteractionForHubGate(Task.getTaskHub(task.name));
             if (gateTask && (this.localTeam?.runState.isNewTaskStatus(gateTask) ?? false))
                 this.addSelfInteraction(gateTask);
         }


### PR DESCRIPTION
- Warp gate tasks are now updated before cell tasks on resync/reboot to ensure gondola is made active if village3-button has been pressed.
- also fixed a few typos OneHand