### PR TITLE
Add Verify Path dev button

### DIFF
--- a/src/app/settings-components/install/install.component.html
+++ b/src/app/settings-components/install/install.component.html
@@ -116,7 +116,14 @@
                     <div *ngIf="_user.user.clientInDevMode" class="mods-dev">
                         <p>OpenGOAL Install Path:</p>
                         <p>{{ _user.user.ogFolderpath }}</p>
-                        <button (click)="selectPath(false)">Change</button>
+                        <div class="dev-container">
+                            <button class="dev-container-content" (click)="selectPath(false)">Change</button>
+                            <button *ngIf="_user.user.gameVersion" class="dev-container-content" (click)="checkForInstall()">Verify path</button>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="dev-container-content-verification" viewBox="0 0 40 40">
+                                <path *ngIf="pathVerificationStatus === 1" class="dev-container-content-verification-checkmark" fill="#00ef00" d="M15.45 32.139L8.125 23.344a2.168 2.168 0 1 1 3.326 -2.77l5.336 6.406L28.329 6.989a2.166 2.166 0 0 1 3.753 2.168L18.987 32.139a2.168 2.168 0 0 1 -3.537 0z"/>
+                                <path *ngIf="pathVerificationStatus === 2" class="dev-container-content-verification-cross" fill="#ef0000" d="M10.039 6.386 19.997 16.344l9.905 -9.905A2.453 2.453 0 0 1 31.661 5.666a2.666 2.666 0 0 1 2.666 2.666 2.4 2.4 0 0 1 -0.72 1.76L23.57 19.997l10.038 10.038A2.4 2.4 0 0 1 34.328 31.661a2.666 2.666 0 0 1 -2.666 2.666 2.453 2.453 0 0 1 -1.84 -0.72L19.997 23.65l-9.931 9.931A2.453 2.453 0 0 1 8.332 34.328a2.666 2.666 0 0 1 -2.666 -2.666 2.4 2.4 0 0 1 0.72 -1.76L16.424 19.997 6.386 9.959A2.4 2.4 0 0 1 5.666 8.332a2.666 2.666 0 0 1 2.666 -2.666c0.64 0.008 1.253 0.267 1.706 0.72"/>
+                            </svg>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/settings-components/install/install.component.scss
+++ b/src/app/settings-components/install/install.component.scss
@@ -80,14 +80,41 @@ color: rgb(255, 255, 255);
 }
 
 .mods {
-  color: #cccccc;
-  font-size: 16px;
-  font-family: OpenSans;
-  margin: 24px;
+    color: #cccccc;
+    font-size: 16px;
+    font-family: OpenSans;
+    margin: 24px;
+    &-section {
+        margin-bottom: 24px;
+    }
+}
 
-  &-section {
-    margin-bottom: 24px;
-  }
+.dev-container {
+    display: flex;
+    align-items: center;
+    color: #cccccc;
+    font-size: 16px;
+    font-family: OpenSans;
+    margin-top: 24px;
+    &-content {
+        & button {
+            width: 125px;
+        }
+        &-verification {
+            width: 40px;
+            height: 40px;
+            stroke-width: 4;
+            stroke-miterlimit: 10;
+            stroke-dashoffset: 0;
+            &-checkmark {
+                stroke: #00ef00;
+            }
+            &-cross {
+                stroke: #ef0000;
+            }
+        }
+    }
+    
 }
 
 .version-mod {

--- a/src/app/settings-components/install/install.component.ts
+++ b/src/app/settings-components/install/install.component.ts
@@ -25,6 +25,7 @@ export class InstallComponent implements OnDestroy {
   storedVersionValue: string;
   isoInstallView: boolean = false;
   needsIsoInstall: boolean = false;
+  pathVerificationStatus : number = 0;  //0 = unknown , 1 = valid , 2 = invalid
   tabForceSet: boolean = false;
   tab: number = 0;
 
@@ -47,7 +48,7 @@ export class InstallComponent implements OnDestroy {
     this.route.queryParamMap.subscribe((params) => {
       
       if (params.get('client') === "1")
-        this.tabForceSet = true; //tab defualt 0 so no need to set
+        this.tabForceSet = true; //tab default 0 so no need to set
       else if (params.get('install') === "1")
         this.moveToGameVersionTab(true);
       else if (params.get('update') === "1")
@@ -67,14 +68,14 @@ export class InstallComponent implements OnDestroy {
   moveToGameVersionTab(needsInstall: boolean) {
     if (needsInstall)
       this.needsIsoInstall = needsInstall;
-    this.tabForceSet = true;
-    this.tab = 1;
-
+    // this.tabForceSet = true;
+    // this.tab = 1;
   }
 
   setupInstallListeners() {
     this.installMissingListener = (window as any).electron.receive("install-missing", () => {
       this.zone.run(() => {
+        this.pathVerificationStatus = 2;
         this.moveToGameVersionTab(true);
       });
     });
@@ -82,6 +83,7 @@ export class InstallComponent implements OnDestroy {
     this.installFoundListener = (window as any).electron.receive("install-found", () => {
       this.zone.run(() => {
         this.needsIsoInstall = false;
+        this.pathVerificationStatus = 1;
       });
     });
   }
@@ -94,6 +96,7 @@ export class InstallComponent implements OnDestroy {
           this.installGameVersion(this.storedVersionValue, path);
         else {
           this._user.user.ogFolderpath = path;
+          this.pathVerificationStatus = 0;
           this.writeSettings();
         }
       });

--- a/src/app/settings-components/install/install.component.ts
+++ b/src/app/settings-components/install/install.component.ts
@@ -68,8 +68,8 @@ export class InstallComponent implements OnDestroy {
   moveToGameVersionTab(needsInstall: boolean) {
     if (needsInstall)
       this.needsIsoInstall = needsInstall;
-    // this.tabForceSet = true;
-    // this.tab = 1;
+    this.tabForceSet = true;
+    this.tab = 1;
   }
 
   setupInstallListeners() {


### PR DESCRIPTION
- This used to be called "Recheck file path" or something.
- Added it back and gave it a visual indicator on whether the path was deemed valid or not.
> ideally pressing this button would also update the launcher's field for which game version is installed?

Fixes #30 